### PR TITLE
Persist media thumbnails and lazy-load editor panels

### DIFF
--- a/apps/web/src/app/editor/[project_id]/page.tsx
+++ b/apps/web/src/app/editor/[project_id]/page.tsx
@@ -2,21 +2,51 @@
 
 import { useEffect, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import {
   ResizablePanelGroup,
   ResizablePanel,
   ResizableHandle,
 } from "@/components/ui/resizable";
-import { MediaPanel } from "@/components/editor/media-panel";
-import { PropertiesPanel } from "@/components/editor/properties-panel";
-import { Timeline } from "@/components/editor/timeline";
-import { PreviewPanel } from "@/components/editor/preview-panel";
+// import { MediaPanel } from "@/components/editor/media-panel";
+// import { PropertiesPanel } from "@/components/editor/properties-panel";
+// import { Timeline } from "@/components/editor/timeline";
+// import { PreviewPanel } from "@/components/editor/preview-panel";
 import { EditorHeader } from "@/components/editor/editor-header";
 import { usePanelStore } from "@/stores/panel-store";
 import { useProjectStore } from "@/stores/project-store";
 import { EditorProvider } from "@/components/providers/editor-provider";
 import { usePlaybackControls } from "@/hooks/use-playback-controls";
 import { Onboarding } from "@/components/editor/onboarding";
+
+const Timeline = dynamic(
+  () =>
+    import("@/components/editor/timeline").then((m) => ({
+      default: m.Timeline,
+    })),
+  { ssr: false, loading: () => <div className="w-full h-full bg-panel" /> }
+);
+const PreviewPanel = dynamic(
+  () =>
+    import("@/components/editor/preview-panel").then((m) => ({
+      default: m.PreviewPanel,
+    })),
+  { ssr: false, loading: () => <div className="w-full h-full bg-panel" /> }
+);
+const MediaPanel = dynamic(
+  () =>
+    import("@/components/editor/media-panel").then((m) => ({
+      default: m.MediaPanel,
+    })),
+  { ssr: false, loading: () => <div className="w-full h-full bg-panel" /> }
+);
+const PropertiesPanel = dynamic(
+  () =>
+    import("@/components/editor/properties-panel").then((m) => ({
+      default: m.PropertiesPanel,
+    })),
+  { ssr: false, loading: () => <div className="w-full h-full bg-panel" /> }
+);
 
 export default function Editor() {
   const {

--- a/apps/web/src/lib/storage/types.ts
+++ b/apps/web/src/lib/storage/types.ts
@@ -20,6 +20,7 @@ export interface MediaFileData {
   duration?: number;
   ephemeral?: boolean;
   sourceStickerIconName?: string;
+  hasThumbnail?: boolean;
   // File will be stored separately in OPFS
 }
 

--- a/apps/web/src/stores/timeline-store.ts
+++ b/apps/web/src/stores/timeline-store.ts
@@ -1230,9 +1230,8 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
     getProjectThumbnail: async (projectId) => {
       try {
         const tracks = await storageService.loadTimeline(projectId);
-        const mediaItems = await storageService.loadAllMediaFiles(projectId);
 
-        if (!tracks || !mediaItems.length) return null;
+        if (!tracks) return null;
 
         const firstMediaElement = tracks
           .flatMap((track) => track.elements)
@@ -1241,17 +1240,14 @@ export const useTimelineStore = create<TimelineStore>((set, get) => {
 
         if (!firstMediaElement) return null;
 
-        const mediaFile = mediaItems.find(
-          (item) => item.id === firstMediaElement.mediaId
+        const mediaFile = await storageService.loadMediaFile(
+          projectId,
+          firstMediaElement.mediaId
         );
         if (!mediaFile) return null;
 
-        if (mediaFile.type === "video" && mediaFile.file) {
-          const { generateVideoThumbnail } = await import(
-            "@/stores/media-store"
-          );
-          const { thumbnailUrl } = await generateVideoThumbnail(mediaFile.file);
-          return thumbnailUrl;
+        if (mediaFile.type === "video" && mediaFile.thumbnailUrl) {
+          return mediaFile.thumbnailUrl;
         }
         if (mediaFile.type === "image" && mediaFile.url) {
           return mediaFile.url;


### PR DESCRIPTION
## Summary
- Persist media thumbnails in OPFS and load only missing ones on project open
- Use first timeline media for project thumbnails instead of loading all media
- Lazy-load heavy editor panels via dynamic imports to reduce initial bundle

## Testing
- `bun run lint` *(fails: Could not resolve ultracite configuration)*
- `bun run check-types` *(fails: turbo: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b50cf2d2dc83219d1d740724ed2706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Persistent thumbnails for media items per project, displayed without needing regeneration.
  - Project thumbnails now use stored previews when available.

- Performance
  - Editor panels load dynamically with lightweight placeholders for quicker initial render.
  - Media library appears immediately while missing thumbnails generate in the background.
  - Faster, targeted loading of media for timeline and project thumbnails.

- Reliability
  - Thumbnail save/load/deletion is resilient; failures won’t block media usage.
  - Background thumbnail tasks run in parallel without impacting overall app responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->